### PR TITLE
Create mongodb initialization seed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ coverage/
 build/
 dist/
 
+# Seed data
+**/seed/
+
 # misc
 .env
 .env.local

--- a/README.md
+++ b/README.md
@@ -12,5 +12,6 @@
 1. Configure the environment variables
    1. Copy and rename `.env.example` to `.env`
    1. Change the variable values in `.env`
+1. Generate seed data by following instructions in [tools README](tools/README.md)
 1. Start Docker
 1. Start the application with `docker-compose up`

--- a/backend/database/mongodb/initdb.d/init-mongo.sh
+++ b/backend/database/mongodb/initdb.d/init-mongo.sh
@@ -1,3 +1,5 @@
+#! /bin/bash
+
 set -e
 
 mongo <<EOF

--- a/backend/database/mongodb/initdb.d/seed-mongo.sh
+++ b/backend/database/mongodb/initdb.d/seed-mongo.sh
@@ -1,0 +1,33 @@
+#! /bin/bash
+
+BUILDINGS=buildings
+readonly NAME
+ETCURVES=etcurves
+readonly ETCURVES
+SENSORS=sensors
+readonly SENSORS
+
+# import building data
+mongoimport --db $MONGO_INITDB_DATABASE \
+            --username $DB_USERNAME --password $DB_PASSWORD \
+            --type json \
+            --collection $BUILDINGS \
+            --file ../seed/$BUILDINGS.json --jsonArray
+
+# import et curves
+mongoimport --db $MONGO_INITDB_DATABASE \
+            --username $DB_USERNAME --password $DB_PASSWORD \
+            --type json \
+            --collection $ETCURVES \
+            --file ../seed/$ETCURVES.json --jsonArray
+
+# import sensor and timeseries data
+for filename in ../seed/sensors/*.json; 
+do
+    echo $filename
+    mongoimport --db $MONGO_INITDB_DATABASE \
+                --username $DB_USERNAME --password $DB_PASSWORD \
+                --type json \
+                --collection $SENSORS \
+                --file $filename --jsonArray
+done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,10 +24,11 @@ services:
     expose:
       - "27018"
     volumes:
+      - ./backend/database/mongodb/seed/:/seed/
       - ./backend/database/mongodb/mongod.conf:/etc/mongod.conf
       - ./backend/database/mongodb/initdb.d/:/docker-entrypoint-initdb.d/
       - trdk02-mongodb:/data/db/
-    command: --config /etc/mongod.conf
+    command: ["-f", "/etc/mongod.conf"]
   backend:
     container_name: trdk02_ed_backend
     build:


### PR DESCRIPTION
Initialization files for seeding the mongodb during Docker container first setup. Depends on the data transformed from #6 which will generate the data before seeding. This is to keep the git repo small in size instead of uploading the 2GB+ files for database seeding.

Closes #8 